### PR TITLE
sorakun_テーブル選択による住所反映＆ルート保存機能&ルート名修正コンポーネントの作成

### DIFF
--- a/navihour_front/src/views/components/Home.js
+++ b/navihour_front/src/views/components/Home.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import Header from '../common/Header';
 import "../../App.css";
-import Grid from '@material-ui/core/Grid';
 import Map from './maps/Map';
 import BackButtons from './maps/BackButtons';
 import MyNavigation from './maps/MyNavigation';
 import OtherNavigation from './maps/OtherNavigation';
+import NavigationSaveButton from './maps/NavigationSaveButton';
 
 class Home extends React.Component {
-    // ToDo
-    // ここに初期値をいれてください
     constructor(props){
         super(props)
         this.state = {
@@ -25,6 +23,7 @@ class Home extends React.Component {
             },
             route_exist: false
         }
+        this.reloadRef = React.createRef();
     }
 
     setStartAddress = (start_address) => {
@@ -37,6 +36,11 @@ class Home extends React.Component {
     
     setRouteExist = (route_exist) => {
         this.setState({route_exist: route_exist});
+    }
+
+    reloadMyNavigation() {
+        // MyNavigatioonのメソッドを親から叩くための設定
+        this.reloadRef.current.reload(); // this.ref名.currentで実体にアクセス
     }
 
     render() {
@@ -53,6 +57,15 @@ class Home extends React.Component {
                         RouteExist = {this.state.route_exist}
                         setRouteExist = {this.setRouteExist.bind(this)}
                     />
+                    <NavigationSaveButton
+                        App_UserId = {this.props.App_UserId}
+                        // NavigationName = {this.state.start_address["address"].slice(0, 20)}
+                        StartAddress = {this.state.start_address}
+                        GoalAddress = {this.state.goal_address}
+                        setStartAddress = {this.setStartAddress.bind(this)}
+                        setGoalAddress = {this.setGoalAddress.bind(this)}
+                        reloadMyNavigation = {this.reloadMyNavigation.bind(this)}
+                    />
                     <BackButtons
                         StartAddress = {this.state.start_address}
                         GoalAddress = {this.state.goal_address}
@@ -62,11 +75,20 @@ class Home extends React.Component {
                     {/* /ToDo App_UserId の渡し方とかも相談。stateで管理？ */}
                     自分のルート(仮)
                     <MyNavigation
+                        ref = {this.reloadRef}
                         App_UserId = {this.props.App_UserId}
+                        setStartAddress = {this.setStartAddress.bind(this)}
+                        setGoalAddress = {this.setGoalAddress.bind(this)}
+                        setRouteExist = {this.setRouteExist.bind(this)}
+                        Map = {this.state.map}
                     />
                     他人のルート(仮)
                     <OtherNavigation
                         App_UserId = {this.props.App_UserId}
+                        setStartAddress = {this.setStartAddress.bind(this)}
+                        setGoalAddress = {this.setGoalAddress.bind(this)}
+                        setRouteExist = {this.setRouteExist.bind(this)}
+                        Map = {this.state.map}
                     />
                 </div>
             );

--- a/navihour_front/src/views/components/maps/EditNavigation.js
+++ b/navihour_front/src/views/components/maps/EditNavigation.js
@@ -1,0 +1,146 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import TextField from '@material-ui/core/TextField';
+import Typography from '@material-ui/core/Typography';
+import Container from '@material-ui/core/Container';
+import { UseStyles } from '../../../utils/utils';
+import LoadingPage from '../../../utils/LoadingPage';
+import MapIcon from '@material-ui/icons/Map';
+import StarRateIcon from '@material-ui/icons/StarRate';
+import LockIcon from '@material-ui/icons/Lock';
+import Switch from '@material-ui/core/Switch';
+import { postApi } from '../../../utils/Api';
+import "../../../App.css";
+import Dialog from '@material-ui/core/Dialog';
+import { withRouter } from 'react-router';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+
+class EditNavigation extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            isOpen: this.props.row.is_edit_open,
+            navigation_id: this.props.row.navigation_id,
+            navigation_name: this.props.row.navigation,
+            is_favorite: this.props.row.is_favorite,
+            is_private: this.props.row.is_private,
+            is_loding: false,
+        }
+    }
+
+    setMessage = (message) => {
+        this.setState({message: message});
+    }
+
+    setNavigationName = (event) => {
+        this.setState({ navigation_name: event.target.value });
+    };
+
+    changeIsFavorite = () => {
+        this.setState({ is_favorite: !this.state.is_favorite });
+    };
+
+    changeIsPrivate = () => {
+        this.setState({ is_private: !this.state.is_private });
+    };
+
+    changeIsLoading = () => {
+        this.setState({ is_loding: !this.state.is_loding });
+    };
+
+    updateNavigation = () => {
+        this.changeIsLoading();
+        const json = {
+            navigation_id: this.state.navigation_id,
+            navigation_name: this.state.navigation_name,
+            is_favorite: this.state.is_favorite,
+            is_private: this.state.is_private,
+        };
+        console.log(json);
+        postApi("put_navigation", json)
+            .then((return_json) => {
+                if (return_json["result"] === "OK") {
+                    this.props.history.push('/Home');
+                }
+                else {
+                    console.log(return_json["message"]);
+                    this.setMessage("※" + return_json["message"]);
+                }
+                this.changeIsLoading();
+                this.props.chanegeIsEditOpen();
+            });
+    }
+
+    handleClose = () => {
+        this.setState({ isOpen: !this.state.isOpen });
+    };
+
+    render() {
+        return (
+            <Dialog aria-labelledby="simple-dialog-title" open={this.state.isOpen}>
+                <Container component="main" maxWidth="xs">
+                    {this.state.is_loding ? <LoadingPage /> : ""}
+                    <CssBaseline />
+                    <div className={UseStyles.paper}>
+                        <Typography component="h1" variant="h5">
+                            Update Navigations
+                        </Typography>
+                        <form className={UseStyles.form} noValidate>
+                            <TextField
+                                variant="outlined"
+                                margin="normal"
+                                required
+                                fullWidth
+                                defaultValue={this.state.navigation_name}
+                                id={"NavigationName"}
+                                label="Enter Navigation Name"
+                                autoComplete={"NavigationName"}
+                                autoFocus
+                                onChange={this.setNavigationName}
+                            />
+                            <div className="flex">
+                                <StarRateIcon style={{ color: "#004d40" }} />
+                                <Switch
+                                    checked={this.state.is_favorite}
+                                    onChange={this.changeIsFavorite}
+                                    color="primary"
+                                    inputProps={{ 'aria-label': 'primary checkbox' }}
+                                />
+                                <LockIcon />
+                                <Switch
+                                    checked={this.state.is_private}
+                                    onChange={this.changeIsPrivate}
+                                    color="primary"
+                                    inputProps={{ 'aria-label': 'primary checkbox' }}
+                                />
+                                <Button
+                                    style={{ color: "white", backgroundColor: "#004d40" }}
+                                    fullWidth
+                                    variant="contained"
+                                    className={UseStyles.submit}
+                                    onClick={this.updateNavigation}
+                                >
+                                    <MapIcon />Update
+                                </Button>
+                                <Button
+                                    color="default"
+                                    onClick={this.props.chanegeIsEditOpen}
+                                    fullWidth
+                                    to="/Home"
+                                    className={UseStyles.submit}
+                                    variant="contained"
+                                >
+                                    Back <ArrowBackIcon />
+                                </Button>
+                            </div>
+                            <br/><font color="red">{this.state.message}</font>
+                        </form>
+                    </div>
+                </Container>
+            </Dialog>
+        );
+    }
+}
+
+export default withRouter(EditNavigation);

--- a/navihour_front/src/views/components/maps/MyNavigation.js
+++ b/navihour_front/src/views/components/maps/MyNavigation.js
@@ -115,7 +115,7 @@ class MyNavigation extends React.Component {
         });
     }
 
-    chanegeIsEditOpen = (row) => {
+    changeIsEditOpen = (row) => {
         this.setNavigationList(row.navigation_id, "is_edit_open", !row.is_edit_open);
         if(!row.is_edit_open){
             this.reload();
@@ -166,11 +166,11 @@ class MyNavigation extends React.Component {
                                 </TableCell>
                                 <TableCell align="right"><Button onClick={() => { this.changePrivate(row) }}>{row.is_private ? <LockIcon /> : <LockOpenIcon />}</Button></TableCell>
                                 <TableCell align="right">
-                                    <Button onClick={() => { this.chanegeIsEditOpen(row) }}>
+                                    <Button onClick={() => { this.changeIsEditOpen(row) }}>
                                         <EditIcon style={{ color: "#004d40" }}/>
                                     </Button>
                                     {/* サーバ側の更新メソッドが作られたらコメントアウト */}
-                                    {/* {row.is_edit_open ? <EditNavigation chanegeIsEditOpen={() => { this.chanegeIsEditOpen(row) }} row={row}/>: ""}  */}
+                                    {/* {row.is_edit_open ? <EditNavigation changeIsEditOpen={() => { this.changeIsEditOpen(row) }} row={row}/>: ""}  */}
                                 </TableCell>
                                 <TableCell align="right"><Button onClick={() => { this.deleteNavigation(row) }} className="delete-button"><DeleteForeverIcon/></Button></TableCell>
                             </TableRow>

--- a/navihour_front/src/views/components/maps/MyNavigation.js
+++ b/navihour_front/src/views/components/maps/MyNavigation.js
@@ -10,10 +10,10 @@ import { postApi } from '../../../utils/Api';
 import LoadingPage from '../../../utils/LoadingPage';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import EditIcon from '@material-ui/icons/Edit';
+import {CreateRoute} from './map_functions/CreateRoute'
+import EditNavigation from './EditNavigation';
 import "../../../App.css";
 
-// ToDo
-// AddressをNavigationに直す。関数を作って貰ったら修正する。
 
 class MyNavigation extends React.Component {
     constructor(props) {
@@ -25,9 +25,10 @@ class MyNavigation extends React.Component {
         }
     }
 
-    createData = (navigation_id, is_favorite, navigation, navigation_created_time, is_private, is_edit_open) => {
-        return { navigation_id, is_favorite, navigation, navigation_created_time, is_private, is_edit_open };
+    createData = (navigation_id, is_favorite, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng, is_edit_open) => {
+        return { navigation_id, is_favorite, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng, is_edit_open };
     }
+
     changeIsLoading = () => {
         this.setState({ is_loding: !this.state.is_loding });
     };
@@ -47,13 +48,24 @@ class MyNavigation extends React.Component {
         const json = {
             user_id: this.state.user_id
         };
-        postApi("get_all_address", json)
+        postApi("get_my_navigations", json)
         .then((return_json) => {
             const return_my_navigation = [];
-            return_json["all_address_list"].map((row)=>{
-                // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-                const data = this.createData(row.address_id, row.is_favorite, row.address_name, row.address_created_time, row.is_private, false);
-                // const data = this.createData(row.navigation_id, row.is_favorite, row.navigation, row.navigation_created_time, row.is_private, row.is_edit_open, false);
+            return_json["my_navigations_list"].map((row)=>{
+                const data = this.createData(
+                    row.navigation_id, 
+                    row.is_favorite, 
+                    row.navigation_name, 
+                    row.navigation_created_time, 
+                    row.is_private, 
+                    row.is_edit_open, 
+                    row.start_address,
+                    row.start_lat,
+                    row.start_lng,
+                    row.goal_address,
+                    row.goal_lat,
+                    row.goal_lng,
+                    false);
                 return_my_navigation.push(data);
             })
             this.setState({ myNavigationList: return_my_navigation });
@@ -63,15 +75,11 @@ class MyNavigation extends React.Component {
 
     changeFavorite = (row) => {
         this.changeIsLoading();
-        // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-        const send_json = { address_id: row.navigation_id, is_favorite: !row.is_favorite };
-        // const send_json = { navigation_id: row.navigation_id, is_favorite: !row.is_favorite };
-        postApi("favorite_address", send_json)
+        const send_json = { navigation_id: row.navigation_id, is_favorite: !row.is_favorite };
+        postApi("favorite_navigation", send_json)
         .then((return_json) => {
             if(return_json["result"] === "OK"){
-                // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
                 this.setNavigationList(row.navigation_id, "is_favorite", !row.is_favorite);
-                // this.setNavigationList(row.navigation_id, "is_favorite", !row.is_favorite);
             }else{
                 // ToDo　サーバ側でエラーが出た時の処理を書く
             }
@@ -81,15 +89,11 @@ class MyNavigation extends React.Component {
 
     changePrivate = (row) => {
         this.changeIsLoading();
-        // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-        const send_json = { address_id: row.navigation_id, is_private: !row.is_private };
-        // const send_json = { navigation_id: row.navigation_id, is_private: !row.is_private };
-        postApi("private_address", send_json)
+        const send_json = { navigation_id: row.navigation_id, is_private: !row.is_private };
+        postApi("private_navigation", send_json)
         .then((return_json) => {
             if(return_json["result"] === "OK"){
-                // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
                 this.setNavigationList(row.navigation_id, "is_private", !row.is_private);
-                // this.setNavigationList(row.address_id, "is_private", !row.is_private);
             }else{
                 // ToDo　サーバ側でエラーが出た時の処理を書く
             }
@@ -100,7 +104,7 @@ class MyNavigation extends React.Component {
     deleteNavigation = (row) => {
         this.changeIsLoading();
         const send_json = { navigation_id: row.navigation_id };
-        postApi("delete_address", send_json)
+        postApi("delete_navigation", send_json)
         .then((return_json) => {
             if(return_json["result"] === "OK"){
                 this.getMyNavigation();
@@ -112,7 +116,7 @@ class MyNavigation extends React.Component {
     }
 
     chanegeIsEditOpen = (row) => {
-        this.setNavigationList(row.address_id, "is_edit_open", !row.is_edit_open);
+        this.setNavigationList(row.navigation_id, "is_edit_open", !row.is_edit_open);
         if(!row.is_edit_open){
             this.reload();
         }
@@ -144,18 +148,29 @@ class MyNavigation extends React.Component {
                     </TableHead>
                     <TableBody>
                         {this.state.myNavigationList.map((row) => (
-                            <TableRow 
-                                hover
-                            >
+                            <TableRow hover>
                                 <TableCell><Button onClick={() => { this.changeFavorite(row) }}>{row.is_favorite ? <StarRateIcon style={{ color: "#004d40" }} /> : <StarBorderIcon />}</Button></TableCell>
-                                <TableCell align="right">{row.navigation}</TableCell>
+                                <TableCell align="right">
+                                    <Button onClick={
+                                        () => { 
+                                            this.props.setStartAddress({address: row.start_address, lat: row.start_lat, lng: row.start_lng}) 
+                                            this.props.setGoalAddress({address: row.goal_address, lat: row.goal_lat, lng: row.goal_lng})
+                                            // みつおがHomeにMapを持たせたらコメントアウトを解除。選択時にルートを引くようになる想定。
+                                            // CreateRoute(this.props.Map, this.props.StartAddress, this.props.GoalAddress)
+                                            // this.props.setRouteExist(true)
+                                            }
+                                        }
+                                    >
+                                        {row.navigation}
+                                    </Button>
+                                </TableCell>
                                 <TableCell align="right"><Button onClick={() => { this.changePrivate(row) }}>{row.is_private ? <LockIcon /> : <LockOpenIcon />}</Button></TableCell>
                                 <TableCell align="right">
                                     <Button onClick={() => { this.chanegeIsEditOpen(row) }}>
                                         <EditIcon style={{ color: "#004d40" }}/>
                                     </Button>
-                                    {/* EditNavigatin　コンポーネントを作ったらコメントアウト解除
-                                    {/* {row.is_edit_open ? <EditNavigatin chanegeIsEditOpen={() => { this.chanegeIsEditOpen(row) }} row={row}/>: ""} */}
+                                    {/* サーバ側の更新メソッドが作られたらコメントアウト */}
+                                    {/* {row.is_edit_open ? <EditNavigation chanegeIsEditOpen={() => { this.chanegeIsEditOpen(row) }} row={row}/>: ""}  */}
                                 </TableCell>
                                 <TableCell align="right"><Button onClick={() => { this.deleteNavigation(row) }} className="delete-button"><DeleteForeverIcon/></Button></TableCell>
                             </TableRow>

--- a/navihour_front/src/views/components/maps/NavigationSaveButton.js
+++ b/navihour_front/src/views/components/maps/NavigationSaveButton.js
@@ -1,0 +1,75 @@
+import React, { Component, createRef } from 'react'
+import { postApi } from '../../../utils/Api';
+import TextField from '@material-ui/core/TextField';
+import LoadingPage from '../../../utils/LoadingPage';
+
+class NavigationSaveButton extends Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            user_id: this.props.App_UserId,
+            navigation_name: '',
+            is_loding: false,
+            message: ''
+        }
+    }
+
+    changeIsLoading = () => {
+        this.setState({ is_loding: !this.state.is_loding });
+    };
+    
+    changeNavigationName = (event) => {
+        this.setState({ navigation_name: event.target.value });
+    };
+
+    postNavigation = (row) => {
+        this.changeIsLoading();
+        this.setState({ message: "" });
+        var navigation_name = this.props.StartAddress["address"].slice(0, 20);
+        if (this.state.navigation_name !== ""){
+            navigation_name = this.state.navigation_name;
+        }
+        const send_json = {
+            user_id: this.state.user_id, 
+            navigation_name: navigation_name,
+            start_address: this.props.StartAddress["address"], 
+            start_lat: this.props.StartAddress["lat"], 
+            start_lng: this.props.StartAddress["lng"], 
+            goal_address: this.props.GoalAddress["address"], 
+            goal_lat: this.props.GoalAddress["lat"], 
+            goal_lng: this.props.GoalAddress["lng"]
+        } 
+        console.log(send_json);
+        postApi("post_navigations", send_json)
+        .then((return_json) => {
+            if(return_json["result"] === "OK"){
+                this.props.reloadMyNavigation();
+                this.setState({ navigation_name: "" });
+            }else{
+                this.setState({ message: "ルートを選択してください。" });
+            }
+            this.changeIsLoading();
+        });
+    }
+
+    render() {
+        return (
+            <div>
+                {this.state.is_loding ? <LoadingPage /> : ""}
+                <TextField
+                    variant="outlined"
+                    margin="normal"
+                    id={"NavigationName"}
+                    label="Enter Navigation Name"
+                    autoComplete={"NavigationName"}
+                    autoFocus
+                    onChange={this.changeNavigationName}
+                />
+                <button onClick={() => {this.postNavigation()}}>ルート保存</button>
+                <br/><font color="red">{this.state.message}</font>
+            </div>
+        )
+    }
+}
+
+export default NavigationSaveButton;

--- a/navihour_front/src/views/components/maps/OtherNavigation.js
+++ b/navihour_front/src/views/components/maps/OtherNavigation.js
@@ -1,19 +1,10 @@
 import React from 'react';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow} from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
-import StarRateIcon from '@material-ui/icons/StarRate';
-import StarBorderIcon from '@material-ui/icons/StarBorder';
-import LockOpenIcon from '@material-ui/icons/LockOpen';
-import LockIcon from '@material-ui/icons/Lock';
-import Button from '@material-ui/core/Button';
 import { postApi } from '../../../utils/Api';
 import LoadingPage from '../../../utils/LoadingPage';
-import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import EditIcon from '@material-ui/icons/Edit';
+import Button from '@material-ui/core/Button';
 import "../../../App.css";
-
-// ToDo
-// AddressをNavigationに直す。関数を作って貰ったら修正する。
 
 class OtherNavigation extends React.Component {
     constructor(props) {
@@ -25,96 +16,38 @@ class OtherNavigation extends React.Component {
         }
     }
 
-    createData = (navigation_id, is_favorite, navigation, navigation_created_time, is_private, is_edit_open) => {
-        return { navigation_id, is_favorite, navigation, navigation_created_time, is_private, is_edit_open };
+    createData = (navigation_id, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng) => {
+        return { navigation_id, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng};
     }
     changeIsLoading = () => {
         this.setState({ is_loding: !this.state.is_loding });
     };
 
-    setNavigationList = (navigation_id, setKey, setValue) => {
-        const otherNavigationList = this.state.otherNavigationList.slice();
-
-        otherNavigationList.map((navigatiData) => {
-            if (navigatiData.navigation_id === navigation_id){
-                navigatiData[setKey] = setValue;
-            }
-        });
-        this.setState({ otherNavigationList: otherNavigationList });
-    }
-
     getOtherNavigation = () => {
         const json = {
             user_id: this.state.user_id
         };
-        postApi("get_all_address", json)
+        postApi("get_others_navigations", json)
         .then((return_json) => {
             const return_my_navigation = [];
-            return_json["all_address_list"].map((row)=>{
-                // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-                const data = this.createData(row.address_id, row.is_favorite, row.address_name, row.address_created_time, row.is_private, false);
-                // const data = this.createData(row.navigation_id, row.is_favorite, row.navigation, row.navigation_created_time, row.is_private, row.is_edit_open, false);
+            return_json["others_navigations_list"].map((row)=>{
+                const data = this.createData(
+                    row.navigation_id, 
+                    row.navigation_name, 
+                    row.navigation_created_time, 
+                    row.is_private,
+                    row.start_address,
+                    row.start_lat,
+                    row.start_lng,
+                    row.goal_address,
+                    row.goal_lat,
+                    row.goal_lng,
+                    );
                 return_my_navigation.push(data);
             })
             this.setState({ otherNavigationList: return_my_navigation });
             this.changeIsLoading();
         });
-    }
-
-    changeFavorite = (row) => {
-        this.changeIsLoading();
-        // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-        const send_json = { address_id: row.navigation_id, is_favorite: !row.is_favorite };
-        // const send_json = { navigation_id: row.navigation_id, is_favorite: !row.is_favorite };
-        postApi("favorite_address", send_json)
-        .then((return_json) => {
-            if(return_json["result"] === "OK"){
-                this.setNavigationList(row.navigation_id, "is_favorite", !row.is_favorite);
-                // this.setNavigationList(row.navigation_id, "is_favorite", !row.is_favorite);
-            }else{
-                // ToDo
-            }
-            this.changeIsLoading();
-        });
-    }
-
-    changePrivate = (row) => {
-        this.changeIsLoading();
-        // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-        const send_json = { address_id: row.navigation_id, is_private: !row.is_private };
-        // const send_json = { navigation_id: row.navigation_id, is_private: !row.is_private };
-        postApi("private_address", send_json)
-        .then((return_json) => {
-            if(return_json["result"] === "OK"){
-                // サーバ側の実装が完了したらそれに合わせてコメントアウトを外す修正
-                this.setNavigationList(row.navigation_id, "is_private", !row.is_private);
-                // this.setNavigationList(row.address_id, "is_private", !row.is_private);
-            }else{
-                // ToDo　サーバ側でエラーが出た時の処理を書く
-            }
-            this.changeIsLoading();
-        });
-    }
-
-    deleteNavigation = (row) => {
-        this.changeIsLoading();
-        const send_json = { navigation_id: row.navigation_id };
-        postApi("delete_address", send_json)
-        .then((return_json) => {
-            if(return_json["result"] === "OK"){
-                this.getOtherNavigation();
-            }else{
-                // ToDo　サーバ側でエラーが出た時の処理を書く
-                this.changeIsLoading();
-            }
-        });
-    }
-
-    chanegeIsEditOpen = (row) => {
-        this.setNavigationList(row.address_id, "is_edit_open", !row.is_edit_open);
-        if(!row.is_edit_open){
-            this.reload();
-        }
     }
 
     reload = () => {
@@ -134,11 +67,7 @@ class OtherNavigation extends React.Component {
                 <Table aria-label="customized table">
                     <TableHead>
                         <TableRow>
-                            <TableCell>Favorite☆</TableCell>
                             <TableCell align="right">Route</TableCell>
-                            <TableCell align="right">Privete</TableCell>
-                            <TableCell align="right">Edit</TableCell>
-                            <TableCell align="right">Delete</TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
@@ -146,17 +75,20 @@ class OtherNavigation extends React.Component {
                             <TableRow 
                                 hover
                             >
-                                <TableCell><Button onClick={() => { this.changeFavorite(row) }}>{row.is_favorite ? <StarRateIcon style={{ color: "#004d40" }} /> : <StarBorderIcon />}</Button></TableCell>
-                                <TableCell align="right">{row.navigation}</TableCell>
-                                <TableCell align="right"><Button onClick={() => { this.changePrivate(row) }}>{row.is_private ? <LockIcon /> : <LockOpenIcon />}</Button></TableCell>
                                 <TableCell align="right">
-                                    <Button onClick={() => { this.chanegeIsEditOpen(row) }}>
-                                        <EditIcon style={{ color: "#004d40" }}/>
+                                    <Button onClick={
+                                        () => { 
+                                            this.props.setStartAddress({address: row.start_address, lat: row.start_lat, lng: row.start_lng}) 
+                                            this.props.setGoalAddress({address: row.goal_address, lat: row.goal_lat, lng: row.goal_lng})
+                                            // みつおがHomeにMapを持たせたらコメントアウトを解除。選択時にルートを引くようになる想定。
+                                            // CreateRoute(this.props.Map, this.props.StartAddress, this.props.GoalAddress)
+                                            // this.props.setRouteExist(true)
+                                            }
+                                        }
+                                    >
+                                        {row.navigation}
                                     </Button>
-                                    {/* EditNavigatin　コンポーネントを作ったらコメントアウト解除 */}
-                                    {/* {row.is_edit_open ? <EditNavigatin chanegeIsEditOpen={() => { this.chanegeIsEditOpen(row) }} row={row}/>: ""} */}
                                 </TableCell>
-                                <TableCell align="right"><Button onClick={() => { this.deleteNavigation(row) }} className="delete-button"><DeleteForeverIcon/></Button></TableCell>
                             </TableRow>
                         ))
                         }

--- a/navihour_front/src/views/components/maps/OtherNavigation.js
+++ b/navihour_front/src/views/components/maps/OtherNavigation.js
@@ -16,8 +16,8 @@ class OtherNavigation extends React.Component {
         }
     }
 
-    createData = (navigation_id, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng) => {
-        return { navigation_id, navigation, navigation_created_time, is_private, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng};
+    createData = (navigation_id, navigation, navigation_created_time, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng) => {
+        return { navigation_id, navigation, navigation_created_time, start_address, start_lat, start_lng, goal_address, goal_lat, goal_lng};
     }
     changeIsLoading = () => {
         this.setState({ is_loding: !this.state.is_loding });
@@ -35,7 +35,6 @@ class OtherNavigation extends React.Component {
                     row.navigation_id, 
                     row.navigation_name, 
                     row.navigation_created_time, 
-                    row.is_private,
                     row.start_address,
                     row.start_lat,
                     row.start_lng,

--- a/nmproject/mapapp/functions/navigations/get_others_navigations_api.py
+++ b/nmproject/mapapp/functions/navigations/get_others_navigations_api.py
@@ -23,7 +23,7 @@ class GetOthersNavigations(APIView):
             return Response({
                 "result":"OK",
                 "message":"Getting others navigations is success",
-                "my_navigations_list": serializer.data
+                "others_navigations_list": serializer.data
             }, status=status.HTTP_200_OK)
 
         


### PR DESCRIPTION
@NS320 @GitBaBYMan 
一度に大量の修正すんまそん。レビューお願いします。

【修正点】
・テーブルを選択したら、住所が変更されるようにした。
　→みつおの修正マージ後に、コメントアウトを解除することでルートも自動で描画される認識

・ルート名修正コンポーネントを作成
　→サーバサイドの実装が完了したらコメントアウトを解除でOKな認識

・ルート保存ボタンを作成
　・名前を入力しないで保存した場合、スタート地点の住所(最初の20文字)が名前として保存される
　・名前を入力した場合、その名前で保存

・サーバサイド、API名の変更
　・間違ったAPI名を修正(みつおの許可済み)

