### PR TITLE
Mitsuo ゲストアカウント用修正

### DIFF
--- a/navihour_front/src/views/components/Login.js
+++ b/navihour_front/src/views/components/Login.js
@@ -73,15 +73,21 @@ class Login extends React.Component {
   }
 
   // ログイン処理
-  Login = () =>{
-    if(!this.checkInputValue()){
-      return;
+  Login = (isGuest) =>{ 
+    var encryptEmail;
+    var encryptPass;
+    if(isGuest){//ゲストのとき
+      encryptEmail = PublicEncrypt("guest@guest.com");
+      encryptPass = PublicEncrypt("guestguest1");
+    }else{//ゲストじゃないとき
+      if(!this.checkInputValue()){
+        return;
+      }
+      encryptEmail = PublicEncrypt(this.state.email);
+      encryptPass = PublicEncrypt(this.state.password);
     }
-    
-    this.changeIsLoading();
-    var encryptEmail = PublicEncrypt(this.state.email);
-    var encryptPass = PublicEncrypt(this.state.password);
 
+    this.changeIsLoading();
     const json = {email: encryptEmail,
       password: encryptPass};
       
@@ -100,29 +106,6 @@ class Login extends React.Component {
     });
   }
 
-  GuestLogin = () =>{
-    
-    this.changeIsLoading();
-    var encryptEmail = PublicEncrypt("guest@guest.com");
-    var encryptPass = PublicEncrypt("guestguest1");
-
-    const json = {email: encryptEmail,
-      password: encryptPass};
-      
-    postApi("login", json)
-    .then((return_json)=>{
-      if(return_json["result"] === "OK"){
-        this.props.App_SetUserId(return_json["user_id"]);
-        this.props.App_SetBiography(return_json["biography"]);
-        this.props.App_SetIsLogin(true);
-        this.props.history.push('/Home');
-      }
-      else{
-        this.setMessage(return_json["message"]);
-      }
-      this.changeIsLoading();
-    });
-  }
 
   changeIsLoading = () => {
     this.setState({ is_loding: !this.state.is_loding });
@@ -169,7 +152,7 @@ class Login extends React.Component {
             variant="contained"
             color="primary"
             className={UseStyles.submit}
-            onClick={this.Login}
+            onClick={()=>this.Login(false)}
           >
             ログイン
           </Button>
@@ -179,7 +162,7 @@ class Login extends React.Component {
             variant="contained"
             color=''
             className={UseStyles.submit}
-            onClick={this.GuestLogin}
+            onClick={()=>this.Login(true)}
           >
             ゲストログイン
           </Button>

--- a/navihour_front/src/views/components/Login.js
+++ b/navihour_front/src/views/components/Login.js
@@ -100,6 +100,30 @@ class Login extends React.Component {
     });
   }
 
+  GuestLogin = () =>{
+    
+    this.changeIsLoading();
+    var encryptEmail = PublicEncrypt("guest@guest.com");
+    var encryptPass = PublicEncrypt("guestguest1");
+
+    const json = {email: encryptEmail,
+      password: encryptPass};
+      
+    postApi("login", json)
+    .then((return_json)=>{
+      if(return_json["result"] === "OK"){
+        this.props.App_SetUserId(return_json["user_id"]);
+        this.props.App_SetBiography(return_json["biography"]);
+        this.props.App_SetIsLogin(true);
+        this.props.history.push('/Home');
+      }
+      else{
+        this.setMessage(return_json["message"]);
+      }
+      this.changeIsLoading();
+    });
+  }
+
   changeIsLoading = () => {
     this.setState({ is_loding: !this.state.is_loding });
   };
@@ -148,6 +172,16 @@ class Login extends React.Component {
             onClick={this.Login}
           >
             ログイン
+          </Button>
+          <p></p>
+          <Button
+            fullWidth
+            variant="contained"
+            color=''
+            className={UseStyles.submit}
+            onClick={this.GuestLogin}
+          >
+            ゲストログイン
           </Button>
           <Grid container>
             <Grid item xs>

--- a/navihour_front/src/views/components/Login.js
+++ b/navihour_front/src/views/components/Login.js
@@ -73,7 +73,7 @@ class Login extends React.Component {
   }
 
   // ログイン処理
-  Login = (isGuest) =>{ 
+  Login = (isGuest=false) =>{ 
     var encryptEmail;
     var encryptPass;
     if(isGuest){//ゲストのとき
@@ -152,7 +152,7 @@ class Login extends React.Component {
             variant="contained"
             color="primary"
             className={UseStyles.submit}
-            onClick={()=>this.Login(false)}
+            onClick={()=>this.Login()}
           >
             ログイン
           </Button>

--- a/nmproject/mapapp/functions/forget_password_api.py
+++ b/nmproject/mapapp/functions/forget_password_api.py
@@ -8,7 +8,8 @@ from django.core.mail import send_mail
 import random, string
 
 
-
+class ThisIsGuestAccount(Exception):
+    pass
 def random_name(n):
     return ''.join(random.choices(string.ascii_letters + string.digits, k=n))
 
@@ -20,6 +21,8 @@ class ForgetPassword(APIView):
         try:
             encrypt_email = request.data["email"]#requestからemailの取り出し
             email = Crypt.decrypt(encrypt_email)#emailの複合化
+            if(email == "guest@guest.com"):
+                raise ThisIsGuestAccount(Exception)                
             request_email = email
             myuser = MyUser.objects.get(email=request_email)#emailが一致するインスタンスの取り出し                      
 
@@ -45,7 +48,9 @@ class ForgetPassword(APIView):
         
         
         except MyUser.DoesNotExist:#見つからない場合
-            return Response({"result": "NG", "message":"email is not found"},status=status.HTTP_400_BAD_REQUEST)            
+            return Response({"result": "NG", "message":"email is not found"},status=status.HTTP_400_BAD_REQUEST)
+        except ThisIsGuestAccount:
+            return Response({"result": "NG", "message": "Cannot change guest account"},status=status.HTTP_400_BAD_REQUEST)       
         except Exception as e:
             print ('=== Error ===')
             print ('type:' + str(type(e)))

--- a/nmproject/mapapp/functions/put_user_api.py
+++ b/nmproject/mapapp/functions/put_user_api.py
@@ -4,6 +4,8 @@ from rest_framework.views import APIView
 from ..models import MyUser, Address
 
 
+class ThisIsGuestAccount(Exception):
+    pass
 
 class PutUser(APIView):
 
@@ -12,6 +14,8 @@ class PutUser(APIView):
 
         try:
             request_user_id = request.data["user_id"]
+            if (request_user_id == "guest"):
+                raise ThisIsGuestAccount(Exception)
             request_new_user_id = request.data["new_user_id"]
             request_new_name = request.data["new_name"]
             request_new_email = request.data["new_email"]
@@ -34,6 +38,8 @@ class PutUser(APIView):
 
         except MyUser.DoesNotExist:#user_idが無い場合
             return Response({"result": "NG", "message": "user_id is not found"},status=status.HTTP_400_BAD_REQUEST)
+        except ThisIsGuestAccount:
+            return Response({"result": "NG", "message": "Guest account cannot change"},status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             print(e)
             return Response({"result": "NG", "message": "Bad request"},status=status.HTTP_400_BAD_REQUEST)

--- a/nmproject/mapapp/functions/reset_pass_api.py
+++ b/nmproject/mapapp/functions/reset_pass_api.py
@@ -12,7 +12,8 @@ class RequestNewPasswordShortError(Exception):
     pass
 class RequestPasswordDifferentError(Exception):
     pass
-
+class ThisIsGuestAccount(Exception):
+    pass
 
 class ResetPass(APIView):
 
@@ -22,6 +23,8 @@ class ResetPass(APIView):
 
         try:
             request_user_id = request.data["user_id"]
+            if (request_user_id == "guest"):
+                raise ThisIsGuestAccount(Exception)
             encrypt_password = request.data["password"]
             request_password = Crypt.decrypt(encrypt_password)#passwordの復号化
             encrypt_new_password1 = request.data["new_password1"]
@@ -52,6 +55,8 @@ class ResetPass(APIView):
 
         except MyUser.DoesNotExist:#user_idが無い場合
             return Response({"result": "NG", "message": "user_id is not found"},status=status.HTTP_400_BAD_REQUEST)
+        except ThisIsGuestAccount:
+            return Response({"result": "NG", "message": "Guest account cannot change"},status=status.HTTP_400_BAD_REQUEST)
         except RequestNewPasswordDifferentError:
             return Response({"result":"NG", "message":"new_password1 and new_password2 are not match"})
         except RequestNewPasswordShortError:


### PR DESCRIPTION
ゲスト用アカウントでメールとパスワード入力をせずにログインできるようにしました。
ゲストアカウントはパスワード変更・プロフィール修正・パスワード忘れた人用再発行ができないようにサーバーサイドを修正しました。
![ゲスト用](https://user-images.githubusercontent.com/74400324/116834250-25d6b800-abf8-11eb-8cd0-cb6a2d53a621.jpg)
